### PR TITLE
Auto shutdown and discord webhook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,47 +4,72 @@ Basic script to launch your minecraft server when someone tries to join.
 
 ## Current Features
 - Supports all client and server versions >= 1.7
+- Auto shutdown via `stop` command on stdin or via `SIGTERM`
+  - `SIGTERM` is only supported on Linux
+- Discord Webhook notifications
 
-## Planned features
-- Autoshutdown via SIGTERM or rcon
 
 ## How to use
 1. Create your mc_autostart.json file:
     ```
     {
-        "autostart_port": "25565",
-        "server_start_command": "command to start your server",
-        "kick_message": "a message to show on the client when you attempt to join",
-        "offline_motd_message": "motd while the server is offline",
+        "server_start_command": "start command / start script",
+        "kick_message": "kick message",
+        "offline_motd_message": "motd",
         "fake_players": [
             {
-                "id": "VALID UUID -> if not valid, ping request won't work",
-                "name": "Name of player to display in the server-list (set fake_players to [] to disable)"
-            },
+                "id": "valid uuid of player",
+                "name": "player name"
+            }
         ],
         "respect_whitelist": true or false,
-        "mc_version": "1.20.1 game version of the server",
-        "protocol_version": 763 (protocol_version of the server)
+        "mc_version": "game version string",
+        "protocol_version": 763 //(protocol_version of the server),
+        "server_dir": "path to the server directory or . if mc_autostart is in the root dir", // server_start_command will be exectued in this dir
+        "auto_shutdown": true or false, // if the server should shutdown if no players are online - if false mc_autostart exits after the mc server started - auto shutdown will only work if the reported players in the minecraft server list are real players!
+        "auto_shutdown_via_sigterm": false, // set to false if you invoke java directly (server_start_command = java ...), set to true if you use a second script that starts the server AND that can handle SIGTERM (via trap, etc.), SIGTERM only works on Linux, on Windows the server will be forced killed after stop_timeout
+        "start_timeout": 20, // seconds to give the server to start, the server will be force killed and sent to sleep if the timeout is exceeded
+        "stop_timeout": 20, // seconds to give the server to stop, the server will be force killed and sent to sleep if the timeout is exceeded
+        "minimum_time_online": 1, // how long the server should be at least online after waking up
+        "stop_after": 1, // how long the server should stay online after the last player left
+        "discord_webhook_notification": false, // if discord webhook notifications should be send
+        "discord_webhook_url": "your webhook url"
     }
+
     ```
     Working example:
     ```
     {
-        "autostart_port": "25565",
         "server_start_command": "java -Xmx1024M -Xms1024M -jar server.jar nogui",
-        "kick_message": "a message to show on the client when you attempt to join",
-        "offline_motd_message": "motd while the server is offline",
-        "fake_players": [],
+        "kick_message": "Thank you for joining!\u00A7r\n\u00A7aServer is now starting - come back in 3-4 Minutes.",
+        "offline_motd_message": "Minecraft Server\u00A7r\n\u00A74The Server is sleeping! \u00A7aJoin to start.",
+        "fake_players": [
+            {
+                "id": "d8d5a923-7b20-43d8-883b-1150148d6955",
+                "name": "Test"
+            }
+        ],
         "respect_whitelist": false,
         "mc_version": "1.20.1",
-        "protocol_version": 763
+        "protocol_version": 763,
+        "server_dir": "./test_server",
+        "auto_shutdown": true,
+        "auto_shutdown_via_sigterm": false,
+        "start_timeout": 300,
+        "stop_timeout": 60,
+        "minimum_time_online": 300,
+        "stop_after": 300,
+        "discord_webhook_notification": false,
+        "discord_webhook_url": ""
     }
+
     ```
+    > [!IMPORTANT]
+    > Place mc_autostart.py and mc_autostart.json need to be in the same folder!.
 
-> [!IMPORTANT]
-> Place mc_autostart.py and mc_autostart.json in the root directory of your server. The script will pull settings from the server.properties file and the whitelist.
+2. If you use docker for your server, use auto_shutdown_via_sigterm: true and a custom start script that catches the SIGTERM signal to stop the server. This way you can stop the mc server before the host system shutsdown.
 
-2. Start the server:
+3. Start the server:
     ### On windows:
     `py mc_autostart.py` OR `python mc_autostart.py`
     ### On macOS:

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Basic script to launch your minecraft server when someone tries to join.
     }
 
     ```
-    > [!IMPORTANT]
-    > Place mc_autostart.py and mc_autostart.json need to be in the same folder!.
+    
+> [!IMPORTANT]
+> mc_autostart.py and mc_autostart.json need to be in the same folder!.
 
-2. If you use docker for your server, use auto_shutdown_via_sigterm: true and a custom start script that catches the SIGTERM signal to stop the server. This way you can stop the mc server before the host system shutsdown.
+2. If you use docker for your server, use `auto_shutdown_via_sigterm: true` and a custom script that catches the SIGTERM signal to stop the server. This way you can stop the mc server before the host system shutsdown.
 
 3. Start the server:
     ### On windows:

--- a/mc_autostart.py
+++ b/mc_autostart.py
@@ -159,7 +159,7 @@ def send_discord_notification(message: str):
     if MC_AUTOSTART_CONFIG["discord_webhook_notification"] == False:
         return
     if len(message) >= 200:
-        message = message[:-6] + "..."
+        message = message[:195] + "..."
 
     conn = http.client.HTTPSConnection("www.discord.com")
     headers = {"Content-type": "application/json"}


### PR DESCRIPTION
Hello again,

this is not yet done, I just want your input so **please don't merge this yet**.
I added auto shutdown support and a simple discord webhook integration.

This works under windows while starting a server directly (via e.g. `java -Xmx1024M -Xms1024M -jar server.jar nogui`).
However the shutdown is kinda broken because the java process and the server spawn ~2 child processes that can't be stopped via the subprocess module.
That's why I added the `kill_server` function that uses different ways to kill the minecraft server if a forced shutdown is needed.
The graceful shutdown sends the `stop` command to the server though I don't know if that works on every system or with man-in-the-middle script (bash or sh script that should start the server instead of calling java directly).

I will test this setup tomorrow in docker but I did like to know if everything works on your system as well.
I added more config options that are not yet documented. Here is a full working `mc_autostart.json` config:
```
{
    "server_start_command": "java -Xmx1024M -Xms1024M -jar server.jar nogui",
    "kick_message": "Thank you for joining!\u00A7r\n\u00A7aServer is now starting - come back in 3-4 Minutes.",
    "offline_motd_message": "Minecraft Server\u00A7r\n\u00A74The Server is sleeping! \u00A7aJoin to start.",
    "fake_players": [
        {
            "id": "d8d5a923-7b20-43d8-883b-1150148d6955",
            "name": "Test"
        }
    ],
    "respect_whitelist": false,
    "mc_version": "1.20.1",
    "protocol_version": 763,
    "server_dir": "./test_server",
    "auto_shutdown": true,
    "start_timeout": 300,
    "stop_timeout": 300,
    "minimum_time_online": 600,
    "stop_after": 600,
    "discord_webhook_notification": false,
    "discord_webhook_url": "your_url"
}
```
`server_dir` automatically add `/` to the end so be sure that this leads to a folder.

The shutdown works by monitoring the server via a minecraft ping and uses the reported `online` number to determine if users are online. So if a server uses a plugin to report fake players, then the auto-shutdown won't work.
